### PR TITLE
18 reviewer view step 4 finalisation of review

### DIFF
--- a/frontend/components/CourseEvaluation/Justifications/EOCCard.tsx
+++ b/frontend/components/CourseEvaluation/Justifications/EOCCard.tsx
@@ -74,7 +74,7 @@ const EOCCard = (props: Props) => {
               color: developmentLevel ? theme.palette.secondary.main : theme.palette.error.main,
             }}
           >
-            <Typography variant="body2" sx={{ fontWeight: 'bold', pb: 1, pr: 1 }} color="success">
+            <Typography variant="body2" sx={{ fontWeight: 'bold', pb: 1, pr: 1 }}>
               Your Rating:
             </Typography>
             <Typography variant="body2" gutterBottom>
@@ -86,7 +86,7 @@ const EOCCard = (props: Props) => {
               color: justificationText ? theme.palette.secondary.main : theme.palette.error.main,
             }}
           >
-            <Typography variant="body2" sx={{ fontWeight: 'bold', pb: 1, pr: 1 }} color="success">
+            <Typography variant="body2" sx={{ fontWeight: 'bold', pb: 1, pr: 1 }}>
               Your Justification:
             </Typography>
             <Typography variant="body2" gutterBottom>
@@ -101,7 +101,7 @@ const EOCCard = (props: Props) => {
                   : theme.palette.error.main,
               }}
             >
-              <Typography variant="body2" sx={{ fontWeight: 'bold', pb: 1, pr: 1 }} color="success">
+              <Typography variant="body2" sx={{ fontWeight: 'bold', pb: 1, pr: 1 }}>
                 Your Suggestion
               </Typography>
               <Typography variant="body2" gutterBottom>

--- a/frontend/components/Reviewer/AboutStepCard.tsx
+++ b/frontend/components/Reviewer/AboutStepCard.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import Card from '@mui/material/Card';
 import CardHeader from '@mui/material/CardHeader';
-import { getReviewStepsWithState } from '@/components/utils/reviews';
 import Container from '@mui/material/Container';
+import { getReviewStepsWithState } from '@/components/utils/reviews';
 
 type Props = {
   stepIndex: number;

--- a/frontend/components/Reviewer/Assessment/EOCAccordionWithModal.tsx
+++ b/frontend/components/Reviewer/Assessment/EOCAccordionWithModal.tsx
@@ -1,0 +1,68 @@
+import Container from '@mui/material/Container';
+import {
+  CourseEvaluationDetailEntry,
+  DEFAULT_EOC_GENERAL_EOC_SPECIFIC,
+  DEFAULT_EOC_SET_EOC_GENERAL,
+  EocGeneralEocSpecific,
+  EocSetEocGeneral,
+  ReviewListEntry,
+} from 'utils/api';
+import { useState } from 'react';
+import EOCAccordion from '@/components/CourseEvaluation/Justifications/EOCAccordion';
+import EOCAsessmentModal from '@/components/Reviewer/Assessment/EOCAssessmentModal';
+import useModal from '@/components/hooks/useModal';
+
+interface EOCAccordionWithModalType {
+  courseEvaluation: CourseEvaluationDetailEntry;
+  courseReview: ReviewListEntry;
+}
+
+const EOCAccordionWithModal = (props: EOCAccordionWithModalType) => {
+  const { courseEvaluation, courseReview } = props;
+
+  /**
+   * State handlers for selected EOC
+   */
+  const eocModalState = useModal();
+
+  const [currentlySelectedEOCGeneral, setCurrentlySelectedEOCGeneral] = useState<
+    EocSetEocGeneral | undefined
+  >(undefined);
+  const [currentlySelectedEOCSpecific, setCurrentlySelectedEOCSpecific] = useState<
+    EocGeneralEocSpecific | undefined
+  >(undefined);
+
+  const handleSelectEOCSpecificAndGeneral =
+    (eocGeneral: EocSetEocGeneral) => (eocSpecific: EocGeneralEocSpecific) => {
+      setCurrentlySelectedEOCGeneral(eocGeneral);
+      setCurrentlySelectedEOCSpecific(eocSpecific);
+      eocModalState.handleOpen();
+    };
+
+  return (
+    <>
+      {eocModalState.isOpen && (
+        <EOCAsessmentModal
+          courseEvaluation={courseEvaluation}
+          eocGeneral={currentlySelectedEOCGeneral || DEFAULT_EOC_SET_EOC_GENERAL}
+          eocSpecific={currentlySelectedEOCSpecific || DEFAULT_EOC_GENERAL_EOC_SPECIFIC}
+          handleClose={eocModalState.handleClose}
+          review={courseReview}
+        />
+      )}
+
+      <Container maxWidth="xl" sx={{ mt: 2, mb: 2 }}>
+        {courseEvaluation.eoc_set.eoc_generals.map((eocGeneral) => (
+          <EOCAccordion
+            eocGeneral={eocGeneral}
+            key={eocGeneral.id}
+            handleSelectEOCSpecificAndGeneral={handleSelectEOCSpecificAndGeneral}
+            review={courseReview}
+          />
+        ))}
+      </Container>
+    </>
+  );
+};
+
+export default EOCAccordionWithModal;

--- a/frontend/components/Reviewer/ReviewerBottomNavigation.tsx
+++ b/frontend/components/Reviewer/ReviewerBottomNavigation.tsx
@@ -4,14 +4,19 @@ import Button from '@mui/material/Button';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
 import { useRouter } from 'next/router';
+import AreYouSureButton from '../utils/AreYouSureModalButton';
 
 type Props = {
   previousLink?: string;
   nextLink?: string;
   handleSubmit?: () => void;
+  modalConfirmation?: {
+    title: string;
+    description: string;
+  };
 };
 const ReviewerBottomNavigation = (props: Props) => {
-  const { previousLink, nextLink, handleSubmit } = props;
+  const { previousLink, nextLink, handleSubmit, modalConfirmation } = props;
 
   const router = useRouter();
   const handlePrevious = () => {
@@ -43,9 +48,20 @@ const ReviewerBottomNavigation = (props: Props) => {
           Previous
         </Button>
       )}
-      <Button endIcon={<NavigateNextIcon />} variant="contained" onClick={handleNext}>
-        {nextLink ? 'Next' : 'Submit'}
-      </Button>
+      {nextLink && modalConfirmation ? (
+        <Button endIcon={<NavigateNextIcon />} variant="contained" onClick={handleNext}>
+          {nextLink ? 'Next' : 'Submit'}
+        </Button>
+      ) : (
+        <AreYouSureButton
+          buttonProps={{ endIcon: <NavigateNextIcon />, variant: 'contained' }}
+          action={handleNext}
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...modalConfirmation}
+        >
+          Submit
+        </AreYouSureButton>
+      )}
     </Container>
   );
 };
@@ -54,6 +70,7 @@ ReviewerBottomNavigation.defaultProps = {
   previousLink: '',
   nextLink: '',
   handleSubmit: () => {},
+  modalConfirmation: undefined,
 };
 
 export default ReviewerBottomNavigation;

--- a/frontend/components/Reviewer/Submit/SimplifiedDocumentCard.tsx
+++ b/frontend/components/Reviewer/Submit/SimplifiedDocumentCard.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { API_ENDPOINT, Document, ReviewListEntry } from 'utils/api';
+import Box from '@mui/material/Box';
+
+import Grid from '@mui/material/Grid';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import Avatar from '@mui/material/Avatar';
+import { useSWRConfig } from 'swr';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import CommentIcon from '@mui/icons-material/Comment';
+import BookmarkAddedIcon from '@mui/icons-material/BookmarkAdded';
+import CardHeader from '@mui/material/CardHeader';
+import useModal from '@/components/hooks/useModal';
+import CreateEditDocumentModal from '@/components/CourseEvaluation/Documents/CreateEditDocumentModal';
+import useAuthenticatedAPIClient from '@/components/hooks/useAuthenticatedAPIClient';
+import AreYouSureModalButton from '@/components/utils/AreYouSureModalButton';
+import EditReviewDocumentCommentModal from '@/components/Reviewer/Documents/EditReviewDocumentCommentModal';
+
+type Props = {
+  document: Document;
+  review: ReviewListEntry;
+};
+
+const SimplifiedDocumentCard = (props: Props) => {
+  const { document, review } = props;
+
+  const reviewDocument = review?.documents.find(
+    (currentDocumentInIteration) => currentDocumentInIteration.document === document.id,
+  );
+
+  return (
+    <Card>
+      <CardHeader title={document.name} subheader={document.description} />
+      <CardContent>
+        <Box sx={{ color: reviewDocument?.is_viewed ? 'secondary.main' : 'error.main' }}>
+          <Typography sx={{ p: 1, fontWeight: 'bold' }}>
+            {reviewDocument?.is_viewed ? 'Marked as Viewed' : 'Marked as not yet viewed'}
+          </Typography>
+        </Box>
+        <Box sx={{ color: reviewDocument?.comment ? 'secondary.main' : 'inherit' }}>
+          <Typography sx={{ p: 1, fontWeight: 'bold' }}>Your comment (optional):</Typography>
+          <Typography sx={{ p: 1 }} variant="subtitle2">
+            {reviewDocument?.comment || 'None'}
+          </Typography>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default SimplifiedDocumentCard;

--- a/frontend/components/Reviewer/Submit/SimplifiedDocumentCard.tsx
+++ b/frontend/components/Reviewer/Submit/SimplifiedDocumentCard.tsx
@@ -1,27 +1,11 @@
 import React from 'react';
-import { API_ENDPOINT, Document, ReviewListEntry } from 'utils/api';
+import { Document, ReviewListEntry } from 'utils/api';
 import Box from '@mui/material/Box';
 
-import Grid from '@mui/material/Grid';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
-import EditIcon from '@mui/icons-material/Edit';
-import DeleteIcon from '@mui/icons-material/Delete';
-import Stack from '@mui/material/Stack';
-import Chip from '@mui/material/Chip';
-import Avatar from '@mui/material/Avatar';
-import { useSWRConfig } from 'swr';
-import VisibilityIcon from '@mui/icons-material/Visibility';
-import CommentIcon from '@mui/icons-material/Comment';
-import BookmarkAddedIcon from '@mui/icons-material/BookmarkAdded';
 import CardHeader from '@mui/material/CardHeader';
-import useModal from '@/components/hooks/useModal';
-import CreateEditDocumentModal from '@/components/CourseEvaluation/Documents/CreateEditDocumentModal';
-import useAuthenticatedAPIClient from '@/components/hooks/useAuthenticatedAPIClient';
-import AreYouSureModalButton from '@/components/utils/AreYouSureModalButton';
-import EditReviewDocumentCommentModal from '@/components/Reviewer/Documents/EditReviewDocumentCommentModal';
 
 type Props = {
   document: Document;

--- a/frontend/components/hooks/useCourseReview.tsx
+++ b/frontend/components/hooks/useCourseReview.tsx
@@ -4,15 +4,20 @@ import useSWRAuth from './useSWRAuth';
 
 /**
  * Helper hook that pulls out the review id from the url and returns the SWR value for it
+ * @redirectIfDone - If true, will redirect to the review page if the review is done
  */
-const useCourseReview = () => {
+const useCourseReview = (redirectIfDone = true) => {
   const router = useRouter();
   const reviewId = (router.query?.reviewId || '') as string;
 
   const swrResult = useSWRAuth(reviewId ? API_ENDPOINT.REVIEWS.DETAIL(reviewId) : '');
-
   const courseReview = ((swrResult.response?.data as unknown) ||
     DEFAULT_REVIEW_LIST_ENTRY) as ReviewListEntry;
+
+  if (courseReview.date_submitted && redirectIfDone) {
+    router.push(`/`);
+  }
+
   return { courseReview, swr: swrResult };
 };
 

--- a/frontend/components/hooks/useModal.tsx
+++ b/frontend/components/hooks/useModal.tsx
@@ -1,6 +1,12 @@
 import { useState } from 'react';
 
-const useModal = () => {
+export interface ModalStateType {
+  isOpen: boolean;
+  handleOpen: () => void;
+  handleClose: () => void;
+}
+
+const useModal = (): ModalStateType => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleOpen = () => setIsOpen(true);

--- a/frontend/components/utils/AreYouSureModalButton.tsx
+++ b/frontend/components/utils/AreYouSureModalButton.tsx
@@ -8,7 +8,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 
-type Props = {
+export type Props = {
   title?: string;
   description?: string;
   action: any;

--- a/frontend/pages/review/[reviewId]/3-assessment.tsx
+++ b/frontend/pages/review/[reviewId]/3-assessment.tsx
@@ -1,11 +1,3 @@
-import Container from '@mui/material/Container';
-import {
-  DEFAULT_EOC_GENERAL_EOC_SPECIFIC,
-  DEFAULT_EOC_SET_EOC_GENERAL,
-  EocGeneralEocSpecific,
-  EocSetEocGeneral,
-} from 'utils/api';
-import { useState } from 'react';
 import useCourseEvaluation from '@/components/hooks/useCourseEvaluation';
 import useCourseReview from '@/components/hooks/useCourseReview';
 import AboutStepCard from '@/components/Reviewer/AboutStepCard';
@@ -13,9 +5,7 @@ import ReviewerBottomNavigation from '@/components/Reviewer/ReviewerBottomNaviga
 import ReviewProgress from '@/components/Reviewer/ReviewProgress';
 import BodyCard from '@/components/utils/BodyCard';
 import { getReviewStepsWithState } from '@/components/utils/reviews';
-import EOCAccordion from '@/components/CourseEvaluation/Justifications/EOCAccordion';
-import EOCAsessmentModal from '@/components/Reviewer/Assessment/EOCAssessmentModal';
-import useModal from '@/components/hooks/useModal';
+import EOCAccordionWithModal from '@/components/Reviewer/Assessment/EOCAccordionWithModal';
 
 const Assessment = () => {
   const { courseReview } = useCourseReview();
@@ -24,47 +14,11 @@ const Assessment = () => {
   const STEP_INDEX = 2;
   const stepDetails = getReviewStepsWithState(courseReview)[STEP_INDEX];
 
-  /**
-   * State handlers for selected EOC
-   */
-  const eocModalState = useModal();
-
-  const [currentlySelectedEOCGeneral, setCurrentlySelectedEOCGeneral] = useState<
-    EocSetEocGeneral | undefined
-  >(undefined);
-  const [currentlySelectedEOCSpecific, setCurrentlySelectedEOCSpecific] = useState<
-    EocGeneralEocSpecific | undefined
-  >(undefined);
-
-  const handleSelectEOCSpecificAndGeneral =
-    (eocGeneral: EocSetEocGeneral) => (eocSpecific: EocGeneralEocSpecific) => {
-      setCurrentlySelectedEOCGeneral(eocGeneral);
-      setCurrentlySelectedEOCSpecific(eocSpecific);
-      eocModalState.handleOpen();
-    };
   return (
     <BodyCard>
-      {eocModalState.isOpen && (
-        <EOCAsessmentModal
-          courseEvaluation={courseEvaluation}
-          eocGeneral={currentlySelectedEOCGeneral || DEFAULT_EOC_SET_EOC_GENERAL}
-          eocSpecific={currentlySelectedEOCSpecific || DEFAULT_EOC_GENERAL_EOC_SPECIFIC}
-          handleClose={eocModalState.handleClose}
-          review={courseReview}
-        />
-      )}
       <ReviewProgress review={courseReview} />
       <AboutStepCard stepIndex={STEP_INDEX} />
-      <Container maxWidth="xl" sx={{ mt: 2, mb: 2 }}>
-        {courseEvaluation.eoc_set.eoc_generals.map((eocGeneral) => (
-          <EOCAccordion
-            eocGeneral={eocGeneral}
-            key={eocGeneral.id}
-            handleSelectEOCSpecificAndGeneral={handleSelectEOCSpecificAndGeneral}
-            review={courseReview}
-          />
-        ))}
-      </Container>
+      <EOCAccordionWithModal courseEvaluation={courseEvaluation} courseReview={courseReview} />
       <ReviewerBottomNavigation
         previousLink={stepDetails.prevStep}
         nextLink={stepDetails.nextStep}

--- a/frontend/pages/review/[reviewId]/4-submit.tsx
+++ b/frontend/pages/review/[reviewId]/4-submit.tsx
@@ -13,6 +13,19 @@ import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
 import DocumentCard from '@/components/CourseEvaluation/Documents/DocumentCard';
 import SimplifiedDocumentCard from '@/components/Reviewer/Submit/SimplifiedDocumentCard';
+import React, { ReactNode } from 'react';
+
+const StepWrapper = (props: { children: ReactNode; cardTitle: string }) => {
+  const { children, cardTitle } = props;
+  return (
+    <Container maxWidth="xl" sx={{ mt: 2, mb: 2 }}>
+      <Card>
+        <CardHeader title={cardTitle} />
+        <CardContent>{children}</CardContent>
+      </Card>
+    </Container>
+  );
+};
 
 const Submit = () => {
   const { courseReview } = useCourseReview();
@@ -27,41 +40,27 @@ const Submit = () => {
     <BodyCard>
       <ReviewProgress review={courseReview} />
       <AboutStepCard stepIndex={STEP_INDEX} />
-      <Container maxWidth="xl" sx={{ mt: 2, mb: 2 }}>
-        <Card>
-          <CardHeader title={`Step 1 - ${allSteps[0].stepName}`} />
-          <CardContent>
-            <Container maxWidth="xl">
-              {courseReview.eoc_date_viewed ? (
-                <Typography color="secondary.main">
-                  You have read and confirmed that you have understood the elements of competencies.
-                </Typography>
-              ) : (
-                <Typography color="error.main">
-                  You have not yet read and confirmed that you have understood the elements of
-                  competencies.
-                </Typography>
-              )}
-            </Container>
-          </CardContent>
-        </Card>
-      </Container>
-      <Container maxWidth="xl" sx={{ mt: 2, mb: 2 }}>
-        <Card>
-          <CardHeader title={`Step 2 - ${allSteps[1].stepName}`} />
-          <CardContent>
-            <Container maxWidth="xl">
-              <Grid container spacing={2}>
-                {courseEvaluation.documents.map((document) => (
-                  <Grid item sm={12} md={4} key={document.id}>
-                    <SimplifiedDocumentCard document={document} review={courseReview} />
-                  </Grid>
-                ))}
-              </Grid>
-            </Container>
-          </CardContent>
-        </Card>
-      </Container>
+      <StepWrapper cardTitle={`Step 1 - ${allSteps[0].stepName}`}>
+        {courseReview.eoc_date_viewed ? (
+          <Typography color="secondary.main">
+            You have read and confirmed that you have understood the elements of competencies.
+          </Typography>
+        ) : (
+          <Typography color="error.main">
+            You have not yet read and confirmed that you have understood the elements of
+            competencies.
+          </Typography>
+        )}
+      </StepWrapper>
+      <StepWrapper cardTitle={`Step 2 - ${allSteps[1].stepName}`}>
+        <Grid container spacing={2}>
+          {courseEvaluation.documents.map((document) => (
+            <Grid item sm={12} md={4} key={document.id}>
+              <SimplifiedDocumentCard document={document} review={courseReview} />
+            </Grid>
+          ))}
+        </Grid>
+      </StepWrapper>
       <ReviewerBottomNavigation
         previousLink={stepDetails.prevStep}
         nextLink={stepDetails.nextStep}

--- a/frontend/pages/review/[reviewId]/4-submit.tsx
+++ b/frontend/pages/review/[reviewId]/4-submit.tsx
@@ -21,6 +21,7 @@ import { API_ENDPOINT } from 'utils/api';
 import TextField from '@mui/material/TextField';
 import useAuthenticatedAPIClient from '@/components/hooks/useAuthenticatedAPIClient';
 import { useSWRConfig } from 'swr';
+import Alert from '@mui/material/Alert';
 
 const StepWrapper = (props: { children: ReactNode; cardTitle: string }) => {
   const { children, cardTitle } = props;
@@ -47,20 +48,22 @@ const Submit = () => {
   const [error, setError] = useState('');
 
   // An object with key as the step number, value as whether it is done
-  const stepsDoneObject = allSteps.reduce((acc, curr) => {
-    acc[`step${curr.stepNo}`] = curr.done;
-    return acc;
-  }, {} as { [key: string]: boolean });
   const formik = useFormik({
     initialValues: {
       /* Note: The values here should match the field name in the models
         Otherwise, make it match in `onSubmit`
       */
-      ...stepsDoneObject,
-      final_comment: '',
+      step1: allSteps[0].done,
+      step2: allSteps[1].done,
+      step3: allSteps[2].done,
+      final_comment: courseReview.final_comment || '',
     },
     validationSchema: Yup.object({
-      final_comment: Yup.string().required('Required'),
+      // Step should be true
+      step1: Yup.boolean().oneOf([true], 'Step 1 - Please confirm the step is done'),
+      step2: Yup.boolean().oneOf([true], 'Step 2 - Please mark atleast one document as viewed.'),
+      step3: Yup.boolean().oneOf([true], 'Step 3 - Please provide atleast one assessment.'),
+      final_comment: Yup.string().required('Final comment is required'),
     }),
     onSubmit: async (values) => {
       try {
@@ -79,6 +82,7 @@ const Submit = () => {
         setError(error?.message || 'Something went wrong');
       }
     },
+    enableReinitialize: true,
   });
 
   useEffect(() => {
@@ -132,6 +136,11 @@ const Submit = () => {
           helperText={formik.errors.final_comment}
         />
       </StepWrapper>
+      {error && (
+        <Alert variant="filled" severity="error" sx={{ m: 2 }}>
+          {error}
+        </Alert>
+      )}
       <ReviewerBottomNavigation
         previousLink={stepDetails.prevStep}
         nextLink={stepDetails.nextStep}

--- a/frontend/pages/review/[reviewId]/4-submit.tsx
+++ b/frontend/pages/review/[reviewId]/4-submit.tsx
@@ -147,7 +147,7 @@ const Submit = () => {
         modalConfirmation={{
           title: 'Submit Review',
           description:
-            'Are you sure you want to submit the review? Once you have submitted, you cannot edit the review. If you want to edit it, then you have to contact the coordinators or administrators.',
+            'You are about to submit a review. Upon submission of a review, you will lose the ability to edit your review. If you have to edit a review, you will have to contact the coordinator of this unit.',
         }}
       />
     </BodyCard>

--- a/frontend/pages/review/[reviewId]/4-submit.tsx
+++ b/frontend/pages/review/[reviewId]/4-submit.tsx
@@ -1,15 +1,72 @@
+import useCourseEvaluation from '@/components/hooks/useCourseEvaluation';
 import useCourseReview from '@/components/hooks/useCourseReview';
 import AboutStepCard from '@/components/Reviewer/AboutStepCard';
+import ReviewerBottomNavigation from '@/components/Reviewer/ReviewerBottomNavigation';
 import ReviewProgress from '@/components/Reviewer/ReviewProgress';
 import BodyCard from '@/components/utils/BodyCard';
+import { getReviewStepsWithState } from '@/components/utils/reviews';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardHeader from '@mui/material/CardHeader';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Grid from '@mui/material/Grid';
+import DocumentCard from '@/components/CourseEvaluation/Documents/DocumentCard';
+import SimplifiedDocumentCard from '@/components/Reviewer/Submit/SimplifiedDocumentCard';
 
 const Submit = () => {
   const { courseReview } = useCourseReview();
+  const { courseEvaluation } = useCourseEvaluation(courseReview.course_evaluation.id);
+
+  const STEP_INDEX = 3;
+  const allSteps = getReviewStepsWithState(courseReview);
+  const stepDetails = allSteps[STEP_INDEX];
+  const handleSubmit = () => {};
 
   return (
     <BodyCard>
       <ReviewProgress review={courseReview} />
-      <AboutStepCard stepIndex={3} />
+      <AboutStepCard stepIndex={STEP_INDEX} />
+      <Container maxWidth="xl" sx={{ mt: 2, mb: 2 }}>
+        <Card>
+          <CardHeader title={`Step 1 - ${allSteps[0].stepName}`} />
+          <CardContent>
+            <Container maxWidth="xl">
+              {courseReview.eoc_date_viewed ? (
+                <Typography color="secondary.main">
+                  You have read and confirmed that you have understood the elements of competencies.
+                </Typography>
+              ) : (
+                <Typography color="error.main">
+                  You have not yet read and confirmed that you have understood the elements of
+                  competencies.
+                </Typography>
+              )}
+            </Container>
+          </CardContent>
+        </Card>
+      </Container>
+      <Container maxWidth="xl" sx={{ mt: 2, mb: 2 }}>
+        <Card>
+          <CardHeader title={`Step 2 - ${allSteps[1].stepName}`} />
+          <CardContent>
+            <Container maxWidth="xl">
+              <Grid container spacing={2}>
+                {courseEvaluation.documents.map((document) => (
+                  <Grid item sm={12} md={4} key={document.id}>
+                    <SimplifiedDocumentCard document={document} review={courseReview} />
+                  </Grid>
+                ))}
+              </Grid>
+            </Container>
+          </CardContent>
+        </Card>
+      </Container>
+      <ReviewerBottomNavigation
+        previousLink={stepDetails.prevStep}
+        nextLink={stepDetails.nextStep}
+        handleSubmit={handleSubmit}
+      />
     </BodyCard>
   );
 };

--- a/frontend/pages/review/[reviewId]/4-submit.tsx
+++ b/frontend/pages/review/[reviewId]/4-submit.tsx
@@ -1,27 +1,26 @@
-import useCourseEvaluation from '@/components/hooks/useCourseEvaluation';
-import useCourseReview from '@/components/hooks/useCourseReview';
-import AboutStepCard from '@/components/Reviewer/AboutStepCard';
-import ReviewerBottomNavigation from '@/components/Reviewer/ReviewerBottomNavigation';
-import ReviewProgress from '@/components/Reviewer/ReviewProgress';
-import BodyCard from '@/components/utils/BodyCard';
-import { getReviewStepsWithState } from '@/components/utils/reviews';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import Grid from '@mui/material/Grid';
-import DocumentCard from '@/components/CourseEvaluation/Documents/DocumentCard';
-import SimplifiedDocumentCard from '@/components/Reviewer/Submit/SimplifiedDocumentCard';
 import React, { ReactNode, useEffect, useState } from 'react';
-import EOCAccordionWithModal from '@/components/Reviewer/Assessment/EOCAccordionWithModal';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import { API_ENDPOINT } from 'utils/api';
 import TextField from '@mui/material/TextField';
-import useAuthenticatedAPIClient from '@/components/hooks/useAuthenticatedAPIClient';
 import { useSWRConfig } from 'swr';
 import Alert from '@mui/material/Alert';
+import useAuthenticatedAPIClient from '@/components/hooks/useAuthenticatedAPIClient';
+import EOCAccordionWithModal from '@/components/Reviewer/Assessment/EOCAccordionWithModal';
+import SimplifiedDocumentCard from '@/components/Reviewer/Submit/SimplifiedDocumentCard';
+import { getReviewStepsWithState } from '@/components/utils/reviews';
+import BodyCard from '@/components/utils/BodyCard';
+import ReviewProgress from '@/components/Reviewer/ReviewProgress';
+import ReviewerBottomNavigation from '@/components/Reviewer/ReviewerBottomNavigation';
+import AboutStepCard from '@/components/Reviewer/AboutStepCard';
+import useCourseReview from '@/components/hooks/useCourseReview';
+import useCourseEvaluation from '@/components/hooks/useCourseEvaluation';
 
 const StepWrapper = (props: { children: ReactNode; cardTitle: string }) => {
   const { children, cardTitle } = props;

--- a/frontend/pages/review/[reviewId]/4-submit.tsx
+++ b/frontend/pages/review/[reviewId]/4-submit.tsx
@@ -145,6 +145,11 @@ const Submit = () => {
         previousLink={stepDetails.prevStep}
         nextLink={stepDetails.nextStep}
         handleSubmit={formik.handleSubmit}
+        modalConfirmation={{
+          title: 'Submit Review',
+          description:
+            'Are you sure you want to submit the review? Once you have submitted, you cannot edit the review. If you want to edit it, then you have to contact the coordinators or administrators.',
+        }}
       />
     </BodyCard>
   );


### PR DESCRIPTION
## Change Summary
- refactoring changes from #97 to display EOCAccordion in the review page.
- redirect when completed
- review and submit entire user interface with error display

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
When the review is finished, I just redirect the user back to the homepage. Maybe it is a good idea to have a "finish page". Just like IndEAAv1. I might do it in a separate pull request as I need to develop a "read-only version". The "read-only" version of a review will be useful as well for a coordinator wanting to view an individual reviewers remarks #19 