### PR TITLE
100 Fix for X-FORWARDED headers not being passed

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -404,5 +404,6 @@ EMAIL_SUBJECT_PREFIX = f"[IndEAA {APP_ENV}] "
 # Use HTTPS headers
 ###################
 
+# https://stackoverflow.com/questions/62047354/build-absolute-uri-with-https-behind-reverse-proxy
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -399,3 +399,10 @@ EMAIL_ADDRESS_FROM = config("EMAIL_ADDRESS_FROM", "noreply-indeaa@systemhealthla
 
 # This string is prefixed to the beginning of every email (subject).
 EMAIL_SUBJECT_PREFIX = f"[IndEAA {APP_ENV}] "
+
+###################
+# Use HTTPS headers
+###################
+
+USE_X_FORWARDED_HOST = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
## Change Summary
Adds these settings
```py
USE_X_FORWARDED_HOST = True
SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
```

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [na] The change has tests
- [x] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**