### PR TITLE
105 remove use of column flexbox and resort to margin as gaps

### DIFF
--- a/frontend/components/CourseEvaluation/Documents/CreateEditDocumentModal.tsx
+++ b/frontend/components/CourseEvaluation/Documents/CreateEditDocumentModal.tsx
@@ -100,14 +100,13 @@ const EditGeneralInformationModal = (props: Props) => {
           {error}
         </Alert>
       )}
-      <DialogContent
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 2,
-        }}
-      >
-        <Card>
+      <DialogContent>
+        <Card
+          sx={{
+            mt: 2,
+            mb: 2,
+          }}
+        >
           <CardHeader
             title="Document Details"
             subheader="These are the basic details of the document"
@@ -166,7 +165,12 @@ const EditGeneralInformationModal = (props: Props) => {
             />
           </CardContent>
         </Card>
-        <Card>
+        <Card
+          sx={{
+            mt: 2,
+            mb: 2,
+          }}
+        >
           <CardHeader
             title="Document Tags"
             subheader="These are tags that aids to connect relevant Elements of Competency (EOC) to documents"

--- a/frontend/components/CourseEvaluation/Documents/CreateEditDocumentModal.tsx
+++ b/frontend/components/CourseEvaluation/Documents/CreateEditDocumentModal.tsx
@@ -103,8 +103,7 @@ const EditGeneralInformationModal = (props: Props) => {
       <DialogContent>
         <Card
           sx={{
-            mt: 2,
-            mb: 2,
+            m: 2,
           }}
         >
           <CardHeader
@@ -167,8 +166,7 @@ const EditGeneralInformationModal = (props: Props) => {
         </Card>
         <Card
           sx={{
-            mt: 2,
-            mb: 2,
+            m: 2,
           }}
         >
           <CardHeader


### PR DESCRIPTION
## Change Summary
- remove use of flexbox and resort to margin as gaps

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [x] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
The flexbox on column direction is the one responsible in squishing